### PR TITLE
Hotfix/acf pro get field collision fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # woocommerce
 
+Notes:
+https://zapltd.slack.com/archives/C01TR8CANLU/p1750761818024279
+
 After downloading the DNA Payments WooCommerce plugin from GitHub, it would be advisable to rename the zip file to "wc-dnapayments.zip" before uploading and installing it.
+
+
+This is the fix for the draft orders issue that DNA didn't let us release!
+The updated plugin is called "WooCommerce DNA Payments Gateway by Zap" and the version is 3.0.15_ZAP
+Note, before updating, load this page /wp-admin/admin.php?page=wc-settings&tab=checkout&section=dnapayments and  verify the settings match after updating the plugin

--- a/includes/WC_DNA_Payments_Gateway.php
+++ b/includes/WC_DNA_Payments_Gateway.php
@@ -688,6 +688,26 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
         return $response;
     }
 
+	private function get_field($meta, $field) {
+		if ( isset( $meta [ $field ] ) ) {
+			return $meta [ $field ][0];
+		}
+		return '';
+	}
+
+	private function get_address($meta, $prefix) {
+		return array(
+			'firstName'     => $this->get_field( $meta, $prefix . '_first_name' ),
+			'lastName'      => $this->get_field( $meta, $prefix . '_last_name' ),
+			'addressLine1'  => $this->get_field( $meta, $prefix . '_address_1' ),
+			'addressLine2'  => $this->get_field( $meta, $prefix . '_address_2' ),
+			'city'          => $this->get_field( $meta, $prefix . '_city' ),
+			'postalCode'    => $this->get_field( $meta, $prefix . '_postcode' ),
+			'phone'         => $this->get_field( $meta, $prefix . '_phone' ),
+			'country'       => $this->get_field( $meta, $prefix . '_country' ),
+		);
+	}
+
     public function add_card_payment_data() {
 
         $user_id    = get_current_user_id();
@@ -700,25 +720,9 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             return get_site_url( null, add_query_arg( array('result' => $result), 'my-account/payment-methods' ) );
         }
 
-        function get_field($meta, $field) {
-            if ( isset( $meta [ $field ] ) ) {
-                return $meta [ $field ][0];
-            }
-            return '';
-        }
 
-        function get_address($meta, $prefix) {
-            return array(
-                'firstName'     => get_field( $meta, $prefix . '_first_name' ),
-                'lastName'      => get_field( $meta, $prefix . '_last_name' ),
-                'addressLine1'  => get_field( $meta, $prefix . '_address_1' ),
-                'addressLine2'  => get_field( $meta, $prefix . '_address_2' ),
-                'city'          => get_field( $meta, $prefix . '_city' ),
-                'postalCode'    => get_field( $meta, $prefix . '_postcode' ),
-                'phone'         => get_field( $meta, $prefix . '_phone' ),
-                'country'       => get_field( $meta, $prefix . '_country' ),
-            );
-        }
+
+
 
         $paymentData = [
             'transactionType'   => 'VERIFICATION',
@@ -734,13 +738,13 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
                 'callbackUrl'       => get_rest_url(null, 'dnapayments/success-add-card')
             ],
             'customerDetails' => [
-                'email'             => get_field( $meta, 'billing_email' ),
+                'email'             => $this->get_field( $meta, 'billing_email' ),
                 'accountDetails' => [
                     'accountId'     => strval($user_id)
                 ],
-                'billingAddress'    => get_address($meta, 'billing'),
+                'billingAddress'    => $this->get_address($meta, 'billing'),
                 'deliveryDetails' => [
-                    'deliveryAddress' => get_address($meta, 'shipping'),
+                    'deliveryAddress' => $this->get_address($meta, 'shipping'),
                 ]
             ]
         ];

--- a/woocommerce-gateway-dnapayments.php
+++ b/woocommerce-gateway-dnapayments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce DNA Payments Gateway by Zap
  * Plugin URI: https://www.dnapayments.com
  * Description: Take credit card payments on your store.
- * Version: 3.0.15_ZAP
+ * Version: 3.0.16_ZAP
  *
  * Author: DNA Payments Integration
  * Author URI: https://www.dnapayments.com


### PR DESCRIPTION
The `add_card_payment_data` method contains a nested function called `get_field` that collides with ACF's global get_field. This causes `/my-account/add-payment-method/` to fail when clicking the button with error:

```
[06-Aug-2025 16:18:26 UTC] PHP Fatal error:  Cannot redeclare get_field() (previously declared in
/var/www/guitargeargiveaway.co.uk/htdocs/wp-content/plugins/advanced-custom-fields-pro/includes/api/api-template.php:17) 
in /var/www/guitargeargiveaway.co.uk/htdocs/wp-content/
plugins/woocommerce-dnapayments-gateway/includes/WC_DNA_Payments_Gateway.php on line 703
```

This PR moved `get_field` into the class as a method